### PR TITLE
Validation show edit

### DIFF
--- a/app/assets/javascripts/backbone/templates/validations/edit.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/validations/edit.jst.ejs
@@ -1,6 +1,6 @@
 <div id="map"></div>
 
-<div id="sidebar" class="shadow">
+<div id="sidebar" class="shadow simple-form">
   <div class="container-fluid">
     <div class="row-fluid">
       <div class="span12">
@@ -10,7 +10,7 @@
           <div class="form-inputs">
             <div id="other-fields">
 
-              <div class="control-group density <%= validation.habitat %> show-with-mangrove show-with-seagrass show-with-saltmarsh">
+              <div class="control-group density <%= validation.habitat %> show-with-mangrove show-with-seagrass show-with-saltmarsh hidden">
                 <label class="control-label" for="density">Density of habitat</label>
                 <div class="controls">
                   <select class="span12" name="density" id="density">
@@ -34,7 +34,7 @@
                 </div>
               </div>
 
-              <div class="control-group condition <%= validation.habitat %> show-with-mangrove">
+              <div class="control-group condition <%= validation.habitat %> show-with-mangrove hidden">
                 <label class="control-label" for="condition">Condition</label>
                 <div class="controls">
                   <select class="span12" name="condition" id="condition">
@@ -47,7 +47,7 @@
                 </div>
               </div>
 
-              <div class="control-group age <%= validation.habitat %> show-with-mangrove">
+              <div class="control-group age <%= validation.habitat %> show-with-mangrove hidden">
                 <label class="control-label" for="age">Age of habitat</label>
                 <div class="controls">
                   <select class="span12" name="age" id="age">
@@ -60,7 +60,7 @@
                 </div>
               </div>
 
-              <div class="control-group species <%= validation.habitat %> show-with-seagrass">
+              <div class="control-group species <%= validation.habitat %> show-with-seagrass hidden">
                 <label class="control-label" for="species">Species</label>
                 <div class="controls">
                   <select class="span12" name="species" id="species">

--- a/app/assets/javascripts/backbone/templates/validations/edit.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/validations/edit.jst.ejs
@@ -4,11 +4,19 @@
   <div class="container-fluid">
     <div class="row-fluid">
       <div class="span12">
-        <h5>Edit validation</h5>
+        <h1 class="admin__header">Edit validation</h1>
+
 
         <form id="edit-validation" name="validation">
           <div class="form-inputs">
             <div id="other-fields">
+
+              <div class="control-group">
+                <label class="control-label" for="habitat">
+                  Habitat type
+                </label>
+                <div id="habitat"><%= polyglot.t('analysis.' + validation.habitat) %></div>
+              </div>
 
               <div class="control-group density <%= validation.habitat %> show-with-mangrove show-with-seagrass show-with-saltmarsh hidden">
                 <label class="control-label" for="density">Density of habitat</label>

--- a/app/assets/javascripts/backbone/views/validations/edit_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/validations/edit_view.js.coffee
@@ -44,6 +44,8 @@ class BlueCarbon.Views.Validations.EditView extends Backbone.View
 
     this.$("form").backboneLink(@model)
 
+    this.$(".show-with-" + @model.attributes.habitat).removeClass('hidden')
+
     # Action btn-group
     this.$(".btn-group button[data-action='#{@model.get('action')}']").removeClass('btn-primary').addClass('btn-inverse active')
 

--- a/app/views/validations/show.html.erb
+++ b/app/views/validations/show.html.erb
@@ -30,7 +30,7 @@
             <% if @validation.habitat == 'mangrove' || @validation.habitat == 'seagrass' || @validation.habitat == 'saltmarsh' %>
               <dl>
                 <dt>Density:</dt>
-                <dd><%= @validation.density.blank? ? "Unknown" : {1 => "Sparse (&lt;20% cover)", 2 => "Moderate (20-50% cover)", 3 => "Dense (50-80% cover)", 4 => "Very dense (&gt;80% cover)"}[@validation.density] %></dd>
+                <dd><%= @validation.density.blank? ? "Unknown" : {1 => "Sparse (&lt;20% cover)", 2 => "Moderate (20-50% cover)", 3 => "Dense (50-80% cover)", 4 => "Very dense (&gt;80% cover)"}[@validation.density.to_int].html_safe %></dd>
               </dl>
             <% end %>
 
@@ -49,7 +49,7 @@
             <% if(@validation.habitat === 'mangrove') %>
               <dl>
                 <dt>Age:</dt>
-                <dd><%= @validation.age.blank? ? 'Unknown' : {1 => "Natural Mangrove", 2 => "2-10 yrs old", 3 => "10-25 yrs old", 4 => "25-50 yrs old"}[@validation.age] %></dd>
+                <dd><%= @validation.age.blank? ? 'Unknown' : {1 => "Natural Mangrove", 2 => "2-10 yrs old", 3 => "10-25 yrs old", 4 => "25-50 yrs old"}[@validation.age.to_int] %></dd>
               </dl>
             <% end %>
 


### PR DESCRIPTION
Updates the styling on the edit page to match the new page.

Fix a couple of errors accessing data from the validation model in show

Add hiding logic on edit so only fields relevant to the given habitat type are shown.

Sorry about all of the PRs!